### PR TITLE
Issue #26

### DIFF
--- a/headless.module
+++ b/headless.module
@@ -183,7 +183,7 @@ function headless_paragraphs_item($type, $entity_id) {
  * We mimic the core function to add some extra pager data to the
  * returned value.
  */
-function _views_get_view_result($name, $display_id = NULL, $args = null) {
+function _views_get_view_result($name, $display_id = NULL, $args = NULL) {
   array_shift($args);
   if (count($args)) {
     array_shift($args);

--- a/headless.module
+++ b/headless.module
@@ -141,14 +141,14 @@ function headless_views($view) {
  * Page callback for views v2.
  */
 function headless_views_v2($view, $display_id) {
-
+  $args = func_get_args();
   $config = config_get('headless.settings', 'views');
   if ($config[$view] != 1) {
     $json_error = ['code' => 404];
     backdrop_json_output($json_error);
     backdrop_exit();
   }
-  $return = _views_get_view_result($view, $display_id);
+  $return = _views_get_view_result($view, $display_id, $args);
 
   $my_json = [
     'results' => $return['results'],
@@ -183,8 +183,7 @@ function headless_paragraphs_item($type, $entity_id) {
  * We mimic the core function to add some extra pager data to the
  * returned value.
  */
-function _views_get_view_result($name, $display_id = NULL) {
-  $args = func_get_args();
+function _views_get_view_result($name, $display_id = NULL, $args = null) {
   array_shift($args);
   if (count($args)) {
     array_shift($args);


### PR DESCRIPTION
It allows to pass views contextual filters as path arguments. This is, you could filter posts by tid (which needs to be done through contextual filters - exposed filters only allow to filter by term name) by adding a contextual filter to the view. Then you can just add the tid to the endpoint like this:

```
/api/v2/views/posts/page/12?page=1
```
This will show the posts which have the term id 12.

This is for the views v2 end point only.